### PR TITLE
feat: add Claude Code plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "vercel-agent-skills",
+  "description": "Vercel's collection of agent skills for React, Next.js, deployment, and web best practices",
+  "owner": {
+    "name": "Vercel Labs",
+    "url": "https://github.com/vercel-labs"
+  },
+  "plugins": [
+    {
+      "name": "vercel-agent-skills",
+      "source": "./",
+      "description": "Vercel's collection of agent skills for React, Next.js, deployment, and web best practices",
+      "version": "1.0.0",
+      "author": { "name": "Vercel Labs", "url": "https://github.com/vercel-labs" },
+      "homepage": "https://github.com/vercel-labs/agent-skills",
+      "license": "MIT",
+      "category": "development",
+      "keywords": ["vercel", "react", "nextjs", "deployment", "frontend"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "vercel-agent-skills",
+  "description": "Vercel's collection of agent skills for React, Next.js, deployment, and web best practices",
+  "version": "1.0.0",
+  "author": { "name": "Vercel Labs", "url": "https://github.com/vercel-labs" },
+  "homepage": "https://github.com/vercel-labs/agent-skills",
+  "license": "MIT",
+  "keywords": ["vercel", "react", "nextjs", "deployment", "frontend"],
+  "skills": "./skills/"
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so this repo can be installed as a Claude Code plugin from any marketplace
- No changes to existing skills or content

## What this enables

Once merged, any Claude Code marketplace can reference this repo as an external plugin:

```json
{
  "name": "vercel-agent-skills",
  "source": {
    "source": "url",
    "url": "https://github.com/vercel-labs/agent-skills.git",
    "sha": "<pinned-sha>"
  }
}
```

All 9 skills under `./skills/` are automatically discovered via `"skills": "./skills/"` in `plugin.json`.

## Test plan

- [ ] `plugin.json` parses as valid JSON
- [ ] `marketplace.json` parses as valid JSON
- [ ] Skills remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)