### PR TITLE
Scope the nested-VT rule in nextjs.md to match SKILL.md

### DIFF
--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -34,7 +34,7 @@ When following [implementation.md](implementation.md), apply these additions:
 
 ## Layout-Level ViewTransition
 
-**Do NOT add a layout-level VT wrapping `{children}` if pages have their own VTs.** Nested VTs never fire enter/exit when inside a parent VT — page-level enter/exit will silently not work. Remove the layout VT entirely.
+**Do NOT add a layout-level VT wrapping `{children}` if pages have their own VTs.** A nested VT skips its own enter/exit only when it mounts or unmounts *as one unit* with a parent VT, which is exactly what a layout VT wrapping `{children}` causes — page-level enter/exit will silently not work. Remove the layout VT entirely. Nesting is otherwise fine and sometimes required: a child VT inside a *persistent* parent VT fires enter/exit normally, and two nested boundaries are the intended shape for [shared elements inside list items](../SKILL.md#composing-shared-elements-with-list-identity).
 
 A bare `<ViewTransition>` in layout works only if pages have **no** VTs of their own.
 


### PR DESCRIPTION
`references/nextjs.md` states the nested-ViewTransition limitation without qualification. The other two places that describe it both scope it, and `SKILL.md` elsewhere prescribes nesting, so the three statements disagree.

| Location | Current wording |
| --- | --- |
| `references/nextjs.md:37` | "Nested VTs **never** fire enter/exit when inside a parent VT" |
| `SKILL.md:306` | "When a parent VT mounts/unmounts **as one unit** with nested VTs inside it, the nested ones do not fire their own enter/exit... (A child VT mounted inside a *persistent* parent VT fires enter/exit normally.)" |
| `references/patterns.md:298` | "nested VTs skip their own enter/exit **only when** they mount/unmount *as one unit* with a parent VT" |

`SKILL.md` also documents nesting as the intended pattern in ["Composing Shared Elements with List Identity"](https://github.com/vercel-labs/agent-skills/blob/main/skills/react-view-transitions/SKILL.md#composing-shared-elements-with-list-identity): "use two nested `<ViewTransition>` boundaries".

Read on its own, `nextjs.md:37` implies nesting is always fatal to enter/exit, which leads to removing nested boundaries that were correct.

## Change

Scopes the sentence to the mount/unmount-as-one-unit case, keeps the layout-VT guidance it is attached to unchanged, and adds a pointer to the case where nesting is required.

Docs only, single file, single paragraph. No behavioural claim is added or removed.

## Note

`codex/update-view-transitions-skill` also edits this file and currently carries the original sentence, so expect a conflict depending on merge order.