### PR TITLE
react-best-practices: add a cross-process caching example to server-cache-lru

### DIFF
--- a/skills/react-best-practices/AGENTS.md
+++ b/skills/react-best-practices/AGENTS.md
@@ -924,9 +924,38 @@ Use when sequential user actions hit multiple endpoints needing the same data wi
 
 **With Vercel's [Fluid Compute](https://vercel.com/docs/fluid-compute):** LRU caching is especially effective because multiple concurrent requests can share the same function instance and cache. This means the cache persists across requests without needing external storage like Redis.
 
-**In traditional serverless:** Each invocation runs in isolation, so consider Redis for cross-process caching.
+**In traditional serverless:** Each invocation runs in isolation, so an in-memory cache only helps while the same instance stays warm. For cross-process caching, back the LRU with a shared store that every instance reaches over HTTP.
 
-Reference: [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache)
+**With a shared store:**
+
+```typescript
+import { Redis } from '@upstash/redis'
+
+const redis = Redis.fromEnv()  // UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN
+
+export async function getUser(id: string) {
+  const local = cache.get(id)
+  if (local) return local
+
+  const shared = await redis.get<User>(`user:${id}`)
+  if (shared) {
+    cache.set(id, shared)
+    return shared
+  }
+
+  const user = await db.user.findUnique({ where: { id } })
+  cache.set(id, user)
+  await redis.set(`user:${id}`, user, { ex: 300 })  // 5 minutes, matches the LRU ttl
+  return user
+}
+
+// Instance A: DB query, result in LRU + shared store
+// Instance B (cold): LRU miss, shared-store hit, no DB query
+```
+
+Key entries by the data's identity, give them a TTL (`ex`, seconds) so stale data expires without manual invalidation, and never put request- or session-scoped data under a shared key (see [Avoid Shared Module State for Request Data](./server-no-shared-module-state.md)). A REST client runs in both Node.js and Edge runtimes because it uses `fetch` rather than a TCP socket. Projects migrated from `@vercel/kv` keep their `KV_REST_API_URL` / `KV_REST_API_TOKEN` variables; `Redis.fromEnv()` reads those too.
+
+Reference: [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache), [https://vercel.com/docs/redis](https://vercel.com/docs/redis)
 
 ### 3.5 Hoist Static I/O to Module Level
 

--- a/skills/react-best-practices/rules/server-cache-lru.md
+++ b/skills/react-best-practices/rules/server-cache-lru.md
@@ -36,6 +36,35 @@ Use when sequential user actions hit multiple endpoints needing the same data wi
 
 **With Vercel's [Fluid Compute](https://vercel.com/docs/fluid-compute):** LRU caching is especially effective because multiple concurrent requests can share the same function instance and cache. This means the cache persists across requests without needing external storage like Redis.
 
-**In traditional serverless:** Each invocation runs in isolation, so consider Redis for cross-process caching.
+**In traditional serverless:** Each invocation runs in isolation, so an in-memory cache only helps while the same instance stays warm. For cross-process caching, back the LRU with a shared store that every instance reaches over HTTP.
 
-Reference: [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache)
+**With a shared store:**
+
+```typescript
+import { Redis } from '@upstash/redis'
+
+const redis = Redis.fromEnv()  // UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN
+
+export async function getUser(id: string) {
+  const local = cache.get(id)
+  if (local) return local
+
+  const shared = await redis.get<User>(`user:${id}`)
+  if (shared) {
+    cache.set(id, shared)
+    return shared
+  }
+
+  const user = await db.user.findUnique({ where: { id } })
+  cache.set(id, user)
+  await redis.set(`user:${id}`, user, { ex: 300 })  // 5 minutes, matches the LRU ttl
+  return user
+}
+
+// Instance A: DB query, result in LRU + shared store
+// Instance B (cold): LRU miss, shared-store hit, no DB query
+```
+
+Key entries by the data's identity, give them a TTL (`ex`, seconds) so stale data expires without manual invalidation, and never put request- or session-scoped data under a shared key (see [Avoid Shared Module State for Request Data](./server-no-shared-module-state.md)). A REST client runs in both Node.js and Edge runtimes because it uses `fetch` rather than a TCP socket. Projects migrated from `@vercel/kv` keep their `KV_REST_API_URL` / `KV_REST_API_TOKEN` variables; `Redis.fromEnv()` reads those too.
+
+Reference: [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache), [https://vercel.com/docs/redis](https://vercel.com/docs/redis)


### PR DESCRIPTION
## Summary

`rules/server-cache-lru.md` ends with "In traditional serverless: Each invocation runs in isolation, so consider Redis for cross-process caching" but shows no code for it. This PR turns that sentence into a runnable two-tier example: the existing `lru-cache` instance in front, a shared Redis store on miss, TTL matched to the LRU `ttl`, and a pointer to `server-no-shared-module-state` on what must never go under a shared key.

The example uses `@upstash/redis` because it is a REST/`fetch` client (works in Node.js and Edge runtimes) and because Vercel's docs describe Redis Marketplace integrations as the replacement for Vercel KV (https://vercel.com/docs/redis), whose env vars `Redis.fromEnv()` still reads.

Disclosure: I work at Upstash. The content is limited to the caching pattern; happy to rename the client or drop the migration sentence if you prefer a vendor-neutral snippet.

## Changes

- `skills/react-best-practices/rules/server-cache-lru.md`: expand the "In traditional serverless" paragraph, add a `**With a shared store:**` code block and a short note on keys, TTL, and runtime compatibility; add https://vercel.com/docs/redis to the references.
- `skills/react-best-practices/AGENTS.md`: regenerated with the build in `packages/react-best-practices-build` (README "Contributing" step 5). The diff is confined to section 3.4. `test-cases.json` is unchanged (the rule has no Incorrect/Correct blocks), and SKILL.md needs no change: rule count and quick reference are the same.

## Testing

- `build` (`tsx src/build.ts && tsx src/extract-tests.ts`) and `validate` in `packages/react-best-practices-build` pass: 70 rules, 139 test cases, all rule files valid.
- Reviewed formatting against sibling rules (`server-cache-react.md`, `server-hoist-static-io.md`).